### PR TITLE
Support namespaces in tags

### DIFF
--- a/lib/puppet/reports/tagmail.rb
+++ b/lib/puppet/reports/tagmail.rb
@@ -80,7 +80,7 @@ Puppet::Reports.register_report(:tagmail) do
       pos = []
       neg = []
       taglist.sub(/\s+$/,'').split(/\s*,\s*/).each do |tag|
-        unless tag =~ /^!?[-\w\.]+$/
+        unless tag =~ /^!?(?:(::)?[-\w\.]+)*$/
           raise ArgumentError, "Invalid tag #{tag.inspect}"
         end
         case tag

--- a/spec/fixtures/unit/reports/tagmail/tagmail_failers.conf
+++ b/spec/fixtures/unit/reports/tagmail/tagmail_failers.conf
@@ -1,3 +1,4 @@
 tag:
 : abuse@domain.com
 invalid!tag: abuse@domain.com
+invalid:scope: abuse@domain.com

--- a/spec/fixtures/unit/reports/tagmail/tagmail_failers.conf
+++ b/spec/fixtures/unit/reports/tagmail/tagmail_failers.conf
@@ -1,4 +1,4 @@
 tag:
 : abuse@domain.com
 invalid!tag: abuse@domain.com
-invalid:scope: abuse@domain.com
+invalid:namespace: abuse@domain.com

--- a/spec/fixtures/unit/reports/tagmail/tagmail_passers.conf
+++ b/spec/fixtures/unit/reports/tagmail/tagmail_passers.conf
@@ -27,7 +27,7 @@ one, two: abuse@domain.com, testing@domain.com
 # and with weird spacing
 one, two: abuse@domain.com , testing@domain.com
 
-# One with scoping
+# One with namespacing
 one::two: abuse@domain.com
 
 # and a trailing comment

--- a/spec/fixtures/unit/reports/tagmail/tagmail_passers.conf
+++ b/spec/fixtures/unit/reports/tagmail/tagmail_passers.conf
@@ -27,4 +27,7 @@ one, two: abuse@domain.com, testing@domain.com
 # and with weird spacing
 one, two: abuse@domain.com , testing@domain.com
 
+# One with scoping
+one::two: abuse@domain.com
+
 # and a trailing comment


### PR DESCRIPTION
Prior to this commit, the scope separator (double colons) in tags were
not matched, causing an "Invalid tag" error.

As classes get tagged, by default, with their full class name (among
other things), the tagmail report handler did not work as expected.

This commit updates the regular expression to properly match tags that
include the double-colon, allowing default tags to be utilized.

I had a patch for this months ago, but with the removal of tagmail looming and such, a PR was never created.