### PR TITLE
Rewrite README per DOC-1777

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,18 +4,26 @@
 
 1. [Overview](#overview)
 2. [Module Description - What the module does and why it is useful](#module-description)
-3. [Installation and Usage](#installation-and-usage)
-4. [Reference - An under-the-hood peek at what the module is doing and how](#reference)
-5. [Limitations - OS compatibility, etc.](#limitations)
+3. [Setup - The basics of getting started with tagmail](#setup)
+4. [Usage - Configuration options and additional functionality](#usage)
+6. [Limitations - OS compatibility, etc.](#limitations)
+7. [Development - Guide for contributing to the module](#development)
 
 ## Overview
 
-This is a plug-in replacement of the existing built-in tagmail report processor. Tagmail is a very often used feature in Puppet. It is used to send email notifications based on tags associated to resources or classes. The tagmail feature is broken in the JVM based PE 3.7 and is scheduled to be completely removed in PE 4.0. This is a module that provides an alternative and replaces the same functionality as available in tagmail prior to PE 3.7.
+The tagmail module forwards Puppet log messages via email if they include specific tags. It is a replacement for Puppet's built-in tagmail report processor.
 
 ## Module Description
 
-This module is a [report processor](https://docs.puppetlabs.com/guides/reporting.html) plugin to generate a tagmail report. The tagmail report sends specific log messages via email based on the tags that are present in each log message. Tags allow users to set context for resources; for example, one can tag all resources that belong to a particular operating system, location, or any other characteristic. See the [documentation on tags](http://docs.puppetlabs.com/puppet/latest/reference/lang_tags.html) for more information. Tags can also be specified in the `puppet.conf` configuration file to tell the agents to apply only configurations tagged with the specified tags.
-The tagmail report uses the same tags to generate email reports. The tags assigned to the resources are added to the log results, and then Puppet generates email based on matching particular tags with particular email addresses. This matching is configured in a configuration file called `tagmail.conf`. By default, the tagmail.conf file is located in the $confdir directory. This is controlled by the tagmap configuration option in the puppet.conf file. Also ensure that `tagmail` is set as one of the (comma separated) values for the `reports` configuration as shown below:
+The tagmail module replaces Puppet's built-in tagmail feature, which is broken in the JVM-based PE 3.7 and will be completely removed in PE 4.0. The tagmail module provides the same functionality as the tagmail feature.
+
+Tags let you set context for resources, classes, and defines. For example, you can assign a tag to all resources associated with a particular operating system, location, or other characteristic. The tag is then included in all log messages related to those resources. [Read more about tags.](http://docs.puppetlabs.com/puppet/latest/reference/lang_tags.html)
+
+The tagmail module is a [report processor](https://docs.puppetlabs.com/guides/reporting.html) plugin that lets you sort log messages into email reports by pairing particular tags with particular email addresses.
+
+## Setup
+
+In `puppet.conf`, make sure `tagmail` is one of the comma-separated values for the `reports` setting, as shown below:
 
 ```
 [master]
@@ -23,7 +31,7 @@ tagmap = $confdir/tagmail.conf
 reports = puppetdb,console,tagmail
 ```
 
-On the agent ensure pluginsync is enabled. It is enabled by default.
+On the agent, make sure `pluginsync` is enabled. It is enabled by default.
 
 ```
 [agent]
@@ -31,32 +39,34 @@ report = true
 pluginsync = true
 ```
 
-## Installation and Usage
+If you use anti-spam controls such as grey-listing on your mail server, whitelist Puppet's sending email address (controlled by the `reportfrom` setting in `puppet.conf`) to ensure your tagmail reports are not discarded as spam.
 
-To use this report, you must create a `tagmail.conf` file on the puppet master in the location specified by the `tagmap` setting. The value of the tagmap setting can be looked up using `puppet master --configprint tagmap` on the puppet master.  The `tagmail.conf` is a simple file that maps tags to email addresses:  Any log messages in the report that match the specified tags will be sent to the specified email addresses.  Lines in the `tagmail.conf` file consist of a comma-separated list of tags, a colon, and a comma-separated list of email addresses. Tags can be !negated with a leading exclamation mark, which will subtract any messages with that tag from the set of events handled by that line.
+## Usage
 
-Puppet's log levels (`debug`, `info`, `notice`, `warning`, `err`, `alert`, `emerg`, `crit`, and `verbose`) can also be used as tags, and there is an `all` tag that will always match all log messages.
+To configure the tagmail module, create a file called `tagmail.conf`. The location for this file depends on the `tagmap` option in `puppet.conf`. It defaults to the $confdir directory, and you can check its current value by running `puppet master --configprint tagmap` on the Puppet master.
+
+Each line in `tagmail.conf` should include a comma-separated list of tags, a colon, and a comma-separated list of email addresses to receive log messages containing the provided tags.
+
+If you prefix a tag with an exclamation mark, Puppet subtracts any messages with that tag from the line's results.
+
+Puppet's [loglevels](https://docs.puppetlabs.com/references/latest/metaparameter.html#loglevel) (`debug`, `info`, `notice`, `warning`, `err`, `alert`, `emerg`, `crit`, and `verbose`) can also be used as tags, and the `all` tag always matches every log message.
 
 An example `tagmail.conf`:
-```
-all: me@domain.com
-webserver, !mailserver: httpadmins@domain.com
-```
+~~~
+all: me@example.com
+webserver, !mailserver: httpadmins@example.com, you@example.com
+~~~
 
-This will send all messages to `me@domain.com`, and all messages from webservers that are not also from mailservers to `httpadmins@domain.com`.
-
-If you are using anti-spam controls such as grey-listing on your mail server, you should whitelist the sending email address (controlled by `reportfrom` configuration option) to ensure your email is not discarded as spam.
-The tagmail.conf file contains a list of tags and email addresses separated by colons. Multiple tags and email addresses can be specified by separating them with commas.
-
-Other settings can also be optionally in puppet.conf to control the email notification settings: `smtpserver`, `smtpport`, `smtphelo`, `sendmail`.
-
-## Reference
-
-This module has been built in direct response to the ticket below:
-https://tickets.puppetlabs.com/browse/SERVER-62
-
-It is based on the original [tagmail report processor](https://github.com/puppetlabs/puppet/blob/3.7.3/lib/puppet/reports/tagmail.rb) which is a part of core puppet.
+The above example sends all log messages to `me@example.com`, and all messages from webservers that are not also from mailservers to `httpadmins@example.com` and to `you@example.com`.
 
 ## Limitations
 
-This module should be used only for PE >3.7 or Puppet 3.7 onwards and only if using the JVM on the puppet master. For older versions of Puppet or if using the legacy puppet master on Apache/Rack/Passenger, then the tagmail feature built into the core of Puppet should be used.
+This module should be used only with Puppet Enterprise and Puppet versions 3.7 or newer, and only if you're using the JVM on the Puppet master. For older versions of Puppet, or if using the legacy Puppet master on Apache/Rack/Passenger, use Puppet's built-in tagmail feature.
+
+## Development
+
+Puppet Labs modules on the Puppet Forge are open projects, and community contributions are essential for keeping them great. We can't access the huge number of platforms and myriad hardware, software, and deployment configurations that Puppet is intended to serve. We want to keep it as easy as possible to contribute changes so that our modules work in your environment. There are a few guidelines that we need contributors to follow so that we can have a chance of keeping on top of things.
+
+For more information, see our [module contribution guide.](https://docs.puppetlabs.com/forge/contributing.html)
+
+To see who's already involved, see the [list of contributors.](https://github.com/puppetlabs/puppetlabs-tagmail/graphs/contributors)


### PR DESCRIPTION
* Rearrange content per our style guide
* Remove redundant and irrelevant content
* Remove references to puppet.conf options removed in Shallow Gravy
* General copyediting