### PR TITLE
Send mail if there is something to send

### DIFF
--- a/lib/puppet/reports/tagmail.rb
+++ b/lib/puppet/reports/tagmail.rb
@@ -176,18 +176,18 @@ Puppet::Reports.register_report(:tagmail) do
       Puppet.notice "Cannot send tagmail report; no tagmap file #{tagmail_conf_file}"
       return
     end
-
-    metrics = raw_summary['resources'] || {} rescue {}
-
-    if metrics['out_of_sync'] == 0 && metrics['changed'] == 0
-      Puppet.notice "Not sending tagmail report; no changes"
-      return
-    end
-
+    
     taglists = parse(File.read(tagmail_conf_file))
 
     # Now find any appropriately tagged messages.
     reports = match(taglists)
+
+    metrics = raw_summary['resources'] || {} rescue {}
+
+    if metrics['out_of_sync'] == 0 && metrics['changed'] == 0 && reports.nil?
+      Puppet.notice "Not sending tagmail report; no changes or messages"
+      return
+    end
 
     send(reports) unless reports.empty?
   end


### PR DESCRIPTION
Reorder the process function so we can check if there are any reports even though there might be no changes.

This allows facts to generate mail reports even though there are no changes in the current catalog. I ran into this as i have a fact that cuts down almost all changes when a build is running on the ci node so there was no change but a critical message from a fact which would have been very interesting...