### PR TITLE
tagmail.rb update for audit email alerts

### DIFF
--- a/lib/puppet/reports/tagmail.rb
+++ b/lib/puppet/reports/tagmail.rb
@@ -177,9 +177,11 @@ Puppet::Reports.register_report(:tagmail) do
       return
     end
 
-    metrics = raw_summary['resources'] || {} rescue {}
+    metrics = raw_summary || {} rescue {}
+    metrics['resources'] = metrics['resources'] || {} rescue {}
+    metrics['events'] = metrics['events'] || {} rescue {}
 
-    if metrics['out_of_sync'] == 0 && metrics['changed'] == 0
+    if metrics['resources']['out_of_sync'] == 0 && metrics['resources']['changed'] == 0 && metrics['events']['audit'] == nil
       Puppet.notice "Not sending tagmail report; no changes"
       return
     end

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "puppetlabs-tagmail",
-  "version": "2.1.1",
+  "version": "2.1.2",
   "author": "puppetlabs",
   "summary": "This module provides a report processor that sends events to email addresses based on tagging of resources",
   "license": "Apache-2.0",


### PR DESCRIPTION
I have updated tagmail.rb file to send the alerts when there are audit failures as well.

https://tickets.puppetlabs.com/browse/MODULES-3509