### PR TITLE
(MODULES-4873) mod install in spec should fail

### DIFF
--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -17,7 +17,7 @@ RSpec.configure do |c|
   c.before :suite do
     # Install test dependencies
     hosts.each do |host|
-      on host, puppet('module install puppetlabs-inifile'), { :acceptable_exit_codes => [0,1] }
+      on host, puppet('module install puppetlabs-inifile')
     end
   end
 end


### PR DESCRIPTION
the inifile module is required by tagmail and is installed in spec_helper_acceptance. the operation accepts a 1 exit code, though, making a ci failure difficult to discern. this changes it to only accept 0.