### PR TITLE
(maint) Removing EOL Debian 6(Squeeze)

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -34,7 +34,6 @@
     {
       "operatingsystem": "Debian",
       "operatingsystemrelease": [
-        "6",
         "7",
         "8"
       ]


### PR DESCRIPTION
Debian 6 is EOL and no longer supported according to: https://docs.puppet.com/pe/latest/sys_req_os.html