### PR TITLE
Change - Do not send out reports if there are no resources included

### DIFF
--- a/lib/puppet/reports/tagmail.rb
+++ b/lib/puppet/reports/tagmail.rb
@@ -202,7 +202,7 @@ Puppet::Reports.register_report(:tagmail) do
 
     # Now find any appropriately tagged messages.
     reports = match(taglists)
-
+    reports.reject! { |item| item =~ %r{Applied\ catalog\ in\ .*\ seconds} }
     send(reports) unless reports.empty?
   end
 


### PR DESCRIPTION
Tagmail was previously sending out reports containing a single line of output as follows.

```
2018-12-07 11:20:01 -0500 Puppet (notice): Applied catalog in 9.33 seconds
```

This change avoids sending out unnecessary e-mails that do not contain any useful data.