### PR TITLE
PDK-1501) Fix acceptance stages in Travis CI

### DIFF
--- a/.sync.yml
+++ b/.sync.yml
@@ -24,6 +24,7 @@
       - bundle exec rake litmus:acceptance:parallel
       services: docker
       sudo: required
+      stage: acceptance
     -
       bundler_args:
       dist: trusty
@@ -37,6 +38,7 @@
       - bundle exec rake litmus:acceptance:parallel
       services: docker
       sudo: required
+      stage: acceptance
     -
       bundler_args:
       dist: trusty
@@ -50,6 +52,7 @@
       - bundle exec rake litmus:acceptance:parallel
       services: docker
       sudo: required
+      stage: acceptance
     -
       bundler_args:
       dist: trusty
@@ -63,6 +66,7 @@
       - bundle exec rake litmus:acceptance:parallel
       services: docker
       sudo: required
+      stage: acceptance
     -
       bundler_args:
       dist: trusty
@@ -76,6 +80,7 @@
       - bundle exec rake litmus:acceptance:parallel
       services: docker
       sudo: required
+      stage: acceptance
     -
       bundler_args:
       dist: trusty
@@ -89,6 +94,7 @@
       - bundle exec rake litmus:acceptance:parallel
       services: docker
       sudo: required
+      stage: acceptance
     -
       bundler_args:
       dist: trusty
@@ -102,6 +108,7 @@
       - bundle exec rake litmus:acceptance:parallel
       services: docker
       sudo: required
+      stage: acceptance
     -
       bundler_args:
       dist: trusty
@@ -115,6 +122,7 @@
       - bundle exec rake litmus:acceptance:parallel
       services: docker
       sudo: required
+      stage: acceptance
 
 appveyor.yml:
   delete: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -45,6 +45,7 @@ matrix:
       rvm: 2.5.3
       script: ["bundle exec rake litmus:acceptance:parallel"]
       services: docker
+      stage: acceptance
       sudo: required
     -
       before_script: ["bundle exec rake 'litmus:provision_list[waffle_deb]'", "bundle exec rake 'litmus:install_agent[puppet6]'", "bundle exec rake litmus:install_module"]
@@ -54,6 +55,7 @@ matrix:
       rvm: 2.5.3
       script: ["bundle exec rake litmus:acceptance:parallel"]
       services: docker
+      stage: acceptance
       sudo: required
     -
       before_script: ["bundle exec rake 'litmus:provision_list[waffle_ubuntu]'", "bundle exec rake 'litmus:install_agent[puppet5]'", "bundle exec rake litmus:install_module"]
@@ -63,6 +65,7 @@ matrix:
       rvm: 2.5.3
       script: ["bundle exec rake litmus:acceptance:parallel"]
       services: docker
+      stage: acceptance
       sudo: required
     -
       before_script: ["bundle exec rake 'litmus:provision_list[waffle_ubuntu]'", "bundle exec rake 'litmus:install_agent[puppet6]'", "bundle exec rake litmus:install_module"]
@@ -72,6 +75,7 @@ matrix:
       rvm: 2.5.3
       script: ["bundle exec rake litmus:acceptance:parallel"]
       services: docker
+      stage: acceptance
       sudo: required
     -
       before_script: ["bundle exec rake 'litmus:provision_list[waffle_el6]'", "bundle exec rake 'litmus:install_agent[puppet5]'", "bundle exec rake litmus:install_module"]
@@ -81,6 +85,7 @@ matrix:
       rvm: 2.5.3
       script: ["bundle exec rake litmus:acceptance:parallel"]
       services: docker
+      stage: acceptance
       sudo: required
     -
       before_script: ["bundle exec rake 'litmus:provision_list[waffle_el6]'", "bundle exec rake 'litmus:install_agent[puppet6]'", "bundle exec rake litmus:install_module"]
@@ -90,6 +95,7 @@ matrix:
       rvm: 2.5.3
       script: ["bundle exec rake litmus:acceptance:parallel"]
       services: docker
+      stage: acceptance
       sudo: required
     -
       before_script: ["bundle exec rake 'litmus:provision_list[waffle_el7]'", "bundle exec rake 'litmus:install_agent[puppet5]'", "bundle exec rake litmus:install_module"]
@@ -99,6 +105,7 @@ matrix:
       rvm: 2.5.3
       script: ["bundle exec rake litmus:acceptance:parallel"]
       services: docker
+      stage: acceptance
       sudo: required
     -
       before_script: ["bundle exec rake 'litmus:provision_list[waffle_el7]'", "bundle exec rake 'litmus:install_agent[puppet6]'", "bundle exec rake litmus:install_module"]
@@ -108,6 +115,7 @@ matrix:
       rvm: 2.5.3
       script: ["bundle exec rake litmus:acceptance:parallel"]
       services: docker
+      stage: acceptance
       sudo: required
 branches:
   only:


### PR DESCRIPTION
Previously the Travis CI file was brought under PDK control, however the
sync.yml did not contain the stage settings for the Litmus jobs which meant
that they did not run.  This commit fixes that error and runs PDK Update again