### PR TITLE
(maint) Removing testing of centos6

### DIFF
--- a/provision.yaml
+++ b/provision.yaml
@@ -30,7 +30,6 @@ travis_ub_6:
 travis_el6:
   provisioner: docker
   images:
-  - litmusimage/centos:6
   - litmusimage/oraclelinux:6
   - litmusimage/scientificlinux:6
 travis_el7:


### PR DESCRIPTION
This is due to EOL and we no longer have access to the repos we were using to test.